### PR TITLE
Fix to help get started immediately

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ First of all, you need to find your authentication token for AL:
 4. In Firefox, click the "Storage" tab. In Chrome, click the "Application" tab.
 5. Click cookies on the left.
 6. Find the cooke named `auth` and copy it. It should be a bunch of random-looking numbers and characters.
-7. Create a new file named `.secret` where you cloned this repository containing only your token(yes, the name starts with a dot).
+7. Create a new file named `.secret` where you cloned this repository containing only your token without the quotes(yes, the name starts with a dot).
 
 Open up your terminal, `cd` to this directory and run `yarn install`. 
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -31,7 +31,7 @@ function getAuthCookie(): string {
   if (!fs.existsSync(".secret")) {
     throw new Error("You need to create a .secret file with your auth token.");
   }
-  const secret = fs.readFileSync(".secret").toString();
+  const secret = fs.readFileSync(".secret").toString().replace(/\r?\n|\r/g, '');
   return `auth=${secret}`;
 }
 


### PR DESCRIPTION
Every token I would enter kept getting rejected due to newlines that get included somewhere along the way from the secret file to the webpack so I added a quick replace.

Also clarified in the README that the token is to be used without quotes. I was expecting it to be assigned to a variable and imported but noticed your code functioned differently.

Hoping this helps some other jump into adventureland.